### PR TITLE
Made it possible to have a bagger in multiple cities without duplication, with unit tests

### DIFF
--- a/baggers.html
+++ b/baggers.html
@@ -116,6 +116,7 @@
 
         <script type="text/javascript">
             $(function() {
+                var data = get_denormalized_data();
                 createMapWithVilles(data);
 
                 // decorate data to alternate images

--- a/baggers.html
+++ b/baggers.html
@@ -116,7 +116,8 @@
 
         <script type="text/javascript">
             $(function() {
-                var data = get_denormalized_data();
+                denormalize_data(data);
+
                 createMapWithVilles(data);
 
                 // decorate data to alternate images

--- a/js/baggers.js
+++ b/js/baggers.js
@@ -2016,36 +2016,7 @@ var data = {
             baggers: [
                 {
                     name: "Camille Roux",
-                    bio: "Co-fondateur de Human Coders. Passionné par Ruby, Ruby on Rails, l'entrepreneuriat, le lean startup...",
-                    picture: "http://www.gravatar.com/avatar/29668d9eaaf486727a446f7d03c59f07.jpg?s=250",
-                    websites: [
-                        {title: "Blog", href: "http://www.camilleroux.com"},
-                        {title: "Human Coders", href: "http://humancoders.com"},
-                        {title: "Human Coders Formations", href: "http://formation.humancoders.com"}
-                    ],
-                    twitter: "CamilleRoux",
-                    contact: "camille@humancoders.com",
-                    mail: "camille@humancoders.com",
-                    location: "Montpellier et environs",
-                    sessions: [
-                        {
-                            title: "Ruby",
-                            summary: "Introduction au langage de programmation Ruby"
-                        },
-                        {
-                            title: "Ruby on Rails",
-                            summary: "Présentation de Ruby on Rails, le framework web le plus connu du monde Ruby"
-                        },
-                        {
-                            title: "Lean Startup",
-                            summary: "Découvrez cette approche pramagtique permettant de lancer des sociétés/produits/services en un temps record"
-                        },
-                        {
-                            title: "Comment recruter un bon développeur ?",
-                            summary: "Comment bien définir son besoin ? Quels moyens pour recruter son prochain développeur ? Comment bien rédiger une offre d'emploi ? Où la publier ? Comment donner envie aux développeurs de travailler dans sa société ? Comment améliorer sa marque employeur ?"
-                        }
-                    ],
-                    tags: ["Ruby", "Ruby on Rails", "Entrepreneuriat", "Lean Startup", "Business Model Canvas", "Recrutement", "Formation"]
+                    ref_ville: "Paris"
                 }
             ]
         }, {

--- a/js/baggersUtils.js
+++ b/js/baggersUtils.js
@@ -78,3 +78,33 @@ function displayContactModalWindowMail() {
         });
     });
 }
+
+function walk_baggers_until(fun) {
+  var cities = data.villes;
+  for (var i in cities) {
+    var city = cities[i];
+    var baggers = city.baggers;
+    for (var j in baggers) {
+      var bagger = baggers[j];
+      if (fun(bagger)) return bagger;
+    }
+  }
+}
+
+function get_bagger_by_name(name) {
+  return walk_baggers_until(function(bagger) {
+    return !bagger.ref_ville;
+  });
+}
+
+function get_denormalized_data() {
+  walk_baggers_until(function(bagger) {
+    if (bagger.ref_ville) {
+      var ref_bagger = get_bagger_by_name(bagger.name);
+      for (var k in ref_bagger) {
+        bagger[k] = ref_bagger[k];
+      }
+    }
+  });
+  return data;
+}

--- a/js/baggersUtils.js
+++ b/js/baggersUtils.js
@@ -111,6 +111,14 @@ function get_bagger_by_name(name) {
   });
 }
 
+function get_city_by_name(name) {
+  var cities = data.villes;
+  for (var i in cities) {
+    var city = cities[i];
+    if (city.name == name) return city;
+  }
+}
+
 function get_denormalized_data() {
   walk_baggers_until(function(bagger) {
     if (bagger.ref_ville) {

--- a/js/baggersUtils.js
+++ b/js/baggersUtils.js
@@ -79,7 +79,7 @@ function displayContactModalWindowMail() {
     });
 }
 
-function filter_baggers(fun) {
+function filter_baggers(data, fun) {
   var matches = [];
   var cities = data.villes;
   for (var i in cities) {
@@ -93,7 +93,7 @@ function filter_baggers(fun) {
   return matches;
 }
 
-function walk_baggers_until(fun) {
+function walk_baggers_until(data, fun) {
   var cities = data.villes;
   for (var i in cities) {
     var city = cities[i];
@@ -105,13 +105,13 @@ function walk_baggers_until(fun) {
   }
 }
 
-function get_bagger_by_name(name) {
-  return walk_baggers_until(function(bagger) {
+function get_bagger_by_name(data, name) {
+  return walk_baggers_until(data, function(bagger) {
     return !bagger.ref_ville;
   });
 }
 
-function get_city_by_name(name) {
+function get_city_by_name(data, name) {
   var cities = data.villes;
   for (var i in cities) {
     var city = cities[i];
@@ -119,14 +119,13 @@ function get_city_by_name(name) {
   }
 }
 
-function get_denormalized_data() {
-  walk_baggers_until(function(bagger) {
+function denormalize_data(data) {
+  walk_baggers_until(data, function(bagger) {
     if (bagger.ref_ville) {
-      var ref_bagger = get_bagger_by_name(bagger.name);
+      var ref_bagger = get_bagger_by_name(data, bagger.name);
       for (var k in ref_bagger) {
         bagger[k] = ref_bagger[k];
       }
     }
   });
-  return data;
 }

--- a/js/baggersUtils.js
+++ b/js/baggersUtils.js
@@ -79,6 +79,20 @@ function displayContactModalWindowMail() {
     });
 }
 
+function filter_baggers(fun) {
+  var matches = [];
+  var cities = data.villes;
+  for (var i in cities) {
+    var city = cities[i];
+    var baggers = city.baggers;
+    for (var j in baggers) {
+      var bagger = baggers[j];
+      if (fun(bagger)) matches.push(bagger);
+    }
+  }
+  return matches;
+}
+
 function walk_baggers_until(fun) {
   var cities = data.villes;
   for (var i in cities) {

--- a/js/baggersUtils.js
+++ b/js/baggersUtils.js
@@ -107,7 +107,7 @@ function walk_baggers_until(data, fun) {
 
 function get_bagger_by_name(data, name) {
   return walk_baggers_until(data, function(bagger) {
-    return !bagger.ref_ville;
+    return bagger.name == name && !bagger.ref_ville;
   });
 }
 

--- a/rh/baggers.html
+++ b/rh/baggers.html
@@ -111,6 +111,8 @@
 
         <script type="text/javascript">
             $(function() {
+                denormalize_data(data);
+
                 createMapWithVilles(data);
 
                 // decorate data to alternate images

--- a/rh/js/baggersUtils.js
+++ b/rh/js/baggersUtils.js
@@ -78,3 +78,54 @@ function displayContactModalWindowMail() {
         });
     });
 }
+
+function filter_baggers(data, fun) {
+  var matches = [];
+  var cities = data.villes;
+  for (var i in cities) {
+    var city = cities[i];
+    var baggers = city.baggers;
+    for (var j in baggers) {
+      var bagger = baggers[j];
+      if (fun(bagger)) matches.push(bagger);
+    }
+  }
+  return matches;
+}
+
+function walk_baggers_until(data, fun) {
+  var cities = data.villes;
+  for (var i in cities) {
+    var city = cities[i];
+    var baggers = city.baggers;
+    for (var j in baggers) {
+      var bagger = baggers[j];
+      if (fun(bagger)) return bagger;
+    }
+  }
+}
+
+function get_bagger_by_name(data, name) {
+  return walk_baggers_until(data, function(bagger) {
+    return !bagger.ref_ville;
+  });
+}
+
+function get_city_by_name(data, name) {
+  var cities = data.villes;
+  for (var i in cities) {
+    var city = cities[i];
+    if (city.name == name) return city;
+  }
+}
+
+function denormalize_data(data) {
+  walk_baggers_until(data, function(bagger) {
+    if (bagger.ref_ville) {
+      var ref_bagger = get_bagger_by_name(data, bagger.name);
+      for (var k in ref_bagger) {
+        bagger[k] = ref_bagger[k];
+      }
+    }
+  });
+}

--- a/rh/js/baggersUtils.js
+++ b/rh/js/baggersUtils.js
@@ -107,7 +107,7 @@ function walk_baggers_until(data, fun) {
 
 function get_bagger_by_name(data, name) {
   return walk_baggers_until(data, function(bagger) {
-    return !bagger.ref_ville;
+    return bagger.name == name && !bagger.ref_ville;
   });
 }
 

--- a/tests/baggers-rh.html
+++ b/tests/baggers-rh.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<head>
+    <meta charset="utf-8">
+    <title>Baggers Model Test for RH</title>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css">
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+    <script src="../rh/js/baggers.js"></script>
+    <script src="../rh/js/baggersUtils.js"></script>
+    <script src="baggers.js"></script>
+</body>
+</html>

--- a/tests/baggers.html
+++ b/tests/baggers.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<head>
+    <meta charset="utf-8">
+    <title>Baggers Model Test</title>
+    <link rel="stylesheet" href="http://code.jquery.com/qunit/qunit-1.12.0.css">
+</head>
+<body>
+    <div id="qunit"></div>
+    <div id="qunit-fixture"></div>
+    <script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+    <script src="http://code.jquery.com/qunit/qunit-1.12.0.js"></script>
+    <script src="../js/baggers.js"></script>
+    <script src="../js/baggersUtils.js"></script>
+    <script src="baggers.js"></script>
+</body>
+</html>

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -28,3 +28,16 @@ test('if there is a ref_ville, it is valid', function() {
 test('invalid ref_ville should fail', function() {
   ok(!get_city_by_name(data, 'invalid'), 'no city named "invalid"');
 });
+
+test('attributes correctly copied from ref_ville', function() {
+  var data = { villes: [
+    { name: "Paris", baggers: [ { name: "Jack", contact: "somewhere" } ] },
+    { name: "Tokyo", baggers: [ { name: "Jack", ref_ville: "Paris" } ] }
+  ] };
+  ok(get_city_by_name(data, "Paris"));
+  ok(get_city_by_name(data, "Tokyo"));
+  var jack_in_tokyo = data.villes[1].baggers[0];
+  ok(!jack_in_tokyo.contact, 'Jack has no .contact field in original data');
+  denormalize_data(data);
+  ok(jack_in_tokyo.contact, 'Jack has .contact field in denormalized data');
+});

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -1,0 +1,11 @@
+test('there are cities in data.villes', function() {
+  ok(data.villes.length > 0);
+});
+
+test('there are baggers in each data.villes.baggers', function() {
+  var cities = data.villes;
+  for (var i in cities) {
+    var city = cities[i];
+    ok(city.baggers.length > 0);
+  }
+});

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -18,7 +18,7 @@ test('if there is a ref_ville, it is valid', function() {
     for (var i in matches) {
       var bagger = matches[i];
       var name = bagger.ref_ville;
-      ok(get_city_by_name(name), 'ref_ville ' + name + ' is valid');
+      ok(get_city_by_name(data, name), 'ref_ville ' + name + ' is valid');
     }
   } else {
     ok('no baggers with ref_ville');
@@ -26,5 +26,5 @@ test('if there is a ref_ville, it is valid', function() {
 });
 
 test('invalid ref_ville should fail', function() {
-  ok(!get_city_by_name('invalid'), 'no city named "invalid"');
+  ok(!get_city_by_name(data, 'invalid'), 'no city named "invalid"');
 });

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -9,3 +9,20 @@ test('there are baggers in each data.villes.baggers', function() {
     ok(city.baggers.length > 0);
   }
 });
+
+test('if there is a ref_ville, it is valid', function() {
+  var bagger = walk_baggers_until(function(bagger) {
+    return bagger.ref_ville;
+  });
+  if (bagger) {
+    ok(function() {
+      var cities = data.villes;
+      for (var i in cities) {
+        var city = cities[i];
+        if (city.name == bagger.ref_ville) return 1;
+      }
+    }(), 'ref_ville ' + bagger.ref_ville + ' is valid');
+  } else {
+    ok('no baggers with ref_ville');
+  }
+});

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -17,13 +17,8 @@ test('if there is a ref_ville, it is valid', function() {
   if (matches.length) {
     for (var i in matches) {
       var bagger = matches[i];
-      ok(function() {
-        var cities = data.villes;
-        for (var i in cities) {
-          var city = cities[i];
-          if (city.name == bagger.ref_ville) return 1;
-        }
-      }(), 'ref_ville ' + bagger.ref_ville + ' is valid');
+      var name = bagger.ref_ville;
+      ok(get_city_by_name(name), 'ref_ville ' + name + ' is valid');
     }
   } else {
     ok('no baggers with ref_ville');

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -11,17 +11,20 @@ test('there are baggers in each data.villes.baggers', function() {
 });
 
 test('if there is a ref_ville, it is valid', function() {
-  var bagger = walk_baggers_until(function(bagger) {
+  var matches = filter_baggers(function(bagger) {
     return bagger.ref_ville;
   });
-  if (bagger) {
-    ok(function() {
-      var cities = data.villes;
-      for (var i in cities) {
-        var city = cities[i];
-        if (city.name == bagger.ref_ville) return 1;
-      }
-    }(), 'ref_ville ' + bagger.ref_ville + ' is valid');
+  if (matches.length) {
+    for (var i in matches) {
+      var bagger = matches[i];
+      ok(function() {
+        var cities = data.villes;
+        for (var i in cities) {
+          var city = cities[i];
+          if (city.name == bagger.ref_ville) return 1;
+        }
+      }(), 'ref_ville ' + bagger.ref_ville + ' is valid');
+    }
   } else {
     ok('no baggers with ref_ville');
   }

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -1,12 +1,12 @@
 test('there are cities in data.villes', function() {
-  ok(data.villes.length > 0);
+  ok(data.villes.length);
 });
 
 test('there are baggers in each data.villes.baggers', function() {
   var cities = data.villes;
   for (var i in cities) {
     var city = cities[i];
-    ok(city.baggers.length > 0);
+    ok(city.baggers.length);
   }
 });
 

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -17,8 +17,9 @@ test('if there is a ref_ville, it is valid', function() {
   if (matches.length) {
     for (var i in matches) {
       var bagger = matches[i];
-      var name = bagger.ref_ville;
-      ok(get_city_by_name(data, name), 'ref_ville ' + name + ' is valid');
+      var city_name = bagger.ref_ville;
+      ok(get_city_by_name(data, city_name), 'ref city name ' + city_name + ' is valid');
+      ok(get_bagger_by_name(data, bagger.name), 'ref bagger ' + bagger.name + ' is valid');
     }
   } else {
     ok(true, 'no baggers with ref_ville, so ok');

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -24,3 +24,7 @@ test('if there is a ref_ville, it is valid', function() {
     ok('no baggers with ref_ville');
   }
 });
+
+test('invalid ref_ville should fail', function() {
+  ok(!get_city_by_name('invalid'), 'no city named "invalid"');
+});

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -41,3 +41,30 @@ test('attributes correctly copied from ref_ville', function() {
   denormalize_data(data);
   ok(jack_in_tokyo.contact, 'Jack has .contact field in denormalized data');
 });
+
+function get_any_dup(data) {
+  var unique_users = [];
+  return walk_baggers_until(data, function(bagger) {
+    var key = bagger.name + bagger.contact;
+    if (unique_users.indexOf(key) == -1) {
+      unique_users.push(key);
+    } else {
+      return bagger;
+    }
+  });
+}
+
+test('no dups in original data', function() {
+  var bagger = get_any_dup(data);
+  ok(!bagger, 'no dups');
+});
+
+test('dups in denormalized data', function() {
+  var data = { villes: [
+    { name: "Paris", baggers: [ { name: "Jack", contact: "somewhere" } ] },
+    { name: "Tokyo", baggers: [ { name: "Jack", ref_ville: "Paris" } ] }
+  ] };
+  denormalize_data(data);
+  var bagger = get_any_dup(data);
+  ok(bagger, bagger.name + ' has a dup');
+});

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -10,6 +10,17 @@ test('there are baggers in each data.villes.baggers', function() {
   }
 });
 
+test('get_bagger_by_name', function() {
+  ok(!get_bagger_by_name(data, 'nonexistent'), 'no bagger named "nonexistent"');
+  var dummy = { villes: [
+    { name: "Paris", baggers: [ { name: "Jack", contact: "somewhere" } ] },
+    { name: "Tokyo", baggers: [ { name: "Mike", ref_ville: "Paris" } ] },
+    { name: "Kyoto", baggers: [ { name: "Fred", ref_ville: "Osaka" } ] }
+  ] };
+  ok(!get_bagger_by_name(dummy, 'Mike'), 'bagger with ref_ville is ignored');
+  ok(!get_bagger_by_name(dummy, 'Fred'), 'bagger with ref_ville is ignored');
+});
+
 test('if there is a ref_ville, it is valid', function() {
   var matches = filter_baggers(data, function(bagger) {
     return bagger.ref_ville;

--- a/tests/baggers.js
+++ b/tests/baggers.js
@@ -6,12 +6,12 @@ test('there are baggers in each data.villes.baggers', function() {
   var cities = data.villes;
   for (var i in cities) {
     var city = cities[i];
-    ok(city.baggers.length);
+    ok(city.baggers.length, 'there are baggers in ' + city.name);
   }
 });
 
 test('if there is a ref_ville, it is valid', function() {
-  var matches = filter_baggers(function(bagger) {
+  var matches = filter_baggers(data, function(bagger) {
     return bagger.ref_ville;
   });
   if (matches.length) {
@@ -21,7 +21,7 @@ test('if there is a ref_ville, it is valid', function() {
       ok(get_city_by_name(data, name), 'ref_ville ' + name + ' is valid');
     }
   } else {
-    ok('no baggers with ref_ville');
+    ok(true, 'no baggers with ref_ville, so ok');
   }
 });
 
@@ -34,8 +34,6 @@ test('attributes correctly copied from ref_ville', function() {
     { name: "Paris", baggers: [ { name: "Jack", contact: "somewhere" } ] },
     { name: "Tokyo", baggers: [ { name: "Jack", ref_ville: "Paris" } ] }
   ] };
-  ok(get_city_by_name(data, "Paris"));
-  ok(get_city_by_name(data, "Tokyo"));
   var jack_in_tokyo = data.villes[1].baggers[0];
   ok(!jack_in_tokyo.contact, 'Jack has no .contact field in original data');
   denormalize_data(data);


### PR DESCRIPTION
At first I tried to normalize the `data`, but that didn't really look pretty. So I chose a different solution: if a bagger is in multiple cities, you add the full details in only one of the cities (any of them), and in other locations you add just the name and a `ref_ville` attribute with the name of the city that has the full details. Take for example Camille Roux, his full details are now in Paris, and in Montpellier there's only this:

```
{
  name: "Camille Roux",
  ref_ville: "Paris"
}
```

To make this work, I added a new utility method `denormalize_data(data)` which find the baggers with `ref_ville` element, and copy all elements from their other entry. So on `baggers.html`, before using the `data`, I call `denormalize_data(data)` to duplicate the data of baggers when necessary.
- I added unit tests, look at `tests/baggers.html` or on [my demo page](http://janosgyerik.github.io/BrownBagLunch/tests/baggers.html)
- As an added bonus, the unit tests cover other cases too, so it's a good sanity check after editing `js/baggers.js`. I think you should add on the front page that whenever somebody edits the `js/baggers.js`, they should check the `tests/baggers.html` page to make sure there are no errors.
- I did the same for RH too, and you can find the unit tests for that in `tests/baggers-rh.html` or on [my demo page](http://janosgyerik.github.io/BrownBagLunch/tests/baggers-rh.html) The unit tests are exactly the same for both cases, only the html is different to include the different `baggers.js` files
