### PR TITLE
Move cities list to the left

### DIFF
--- a/baggers.html
+++ b/baggers.html
@@ -89,7 +89,25 @@
       </div>
 
       <div class="row" v-cloak>
-        <div class="col-12 col-sm-10">
+        <!-- Liste des villes -->
+        <div class="col-sm-2 cities-group">
+            <ul class="list-group cities-list">
+              <li class="list-group-item list-group-item-inverse cities-title">Choisissez la ville</li>
+              <li class="list-group-item justify-content-between list-group-item-action city-menu"
+                  :class="{ active: selectedCity === null }"
+                  @click="selectedCity = null">
+                Toutes les villes <span class="badge badge-primary badge-pill">{{ baggers.length }}</span>
+              </li>
+              <li class="list-group-item justify-content-between list-group-item-action city-menu"
+                  :class="{ active: selectedCity === city.name }"
+                  v-for="city in cities"
+                  @click="selectedCity = city.name">
+                {{ city.name }}
+                <span class="badge badge-primary badge-pill">{{ city.baggers }}</span>
+              </li>
+            </ul>
+          </div>
+        <div class="col-10 col-sm-10">
           <div class="alert alert-success" v-if="contact.success" role="alert">
             <i class="fa fa-envelope-o"></i> Votre email a bien été envoyé à <strong>{{ contact.bagger }}</strong>. Bon BBL !
           </div>
@@ -104,7 +122,7 @@
 
           <!-- Liste (filtrée) des baggers... -->
           <div class="row justify-content-center">
-            <div v-for="bagger in filtered(baggers)" class="col-sm-6 col-xs-12">
+            <div v-for="bagger in displayedBaggers" class="col-sm-6 col-xs-12">
               <div class="bagger">
                 <a :id="bagger.id"></a>
                 <div :class="'bagger-header ' + bagger.mainCity">
@@ -157,24 +175,6 @@
           </div>
         </div>
 
-        <!-- Liste des villes -->
-        <div class="col-sm-2">
-          <ul class="list-group cities-list">
-            <li class="list-group-item list-group-item-inverse cities-title">Choisissez la ville</li>
-            <li class="list-group-item justify-content-between list-group-item-action city-menu"
-                :class="{ active: selectedCity === null }"
-                @click="selectedCity = null">
-              Toutes les villes <span class="badge badge-primary badge-pill">{{ baggers.length }}</span>
-            </li>
-            <li class="list-group-item justify-content-between list-group-item-action city-menu"
-                :class="{ active: selectedCity === city.name }"
-                v-for="city in cities"
-                @click="selectedCity = city.name">
-              {{ city.name }}
-              <span class="badge badge-primary badge-pill">{{ city.baggers }}</span>
-            </li>
-          </ul>
-        </div>
       </div>
     </div>
 

--- a/baggers.html
+++ b/baggers.html
@@ -2,7 +2,7 @@
 <!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js" lang="fr"> <!--<![endif]-->
 <head>
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/css/baggers.css
+++ b/css/baggers.css
@@ -3,6 +3,10 @@
   overflow-x: hidden;
 }
 
+.cities-group {
+  padding-left: 0;
+}
+
 .cities-title.list-group-item:first-child {
   border-radius: 0;
   background-color: #292B2C;

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="fr">
         <head>
 			<meta charset="UTF-8" />
             <title>Brown bag lunch France</title>

--- a/js/vue-app.js
+++ b/js/vue-app.js
@@ -21,9 +21,7 @@ new Vue({
     displayedBaggers: function(){
       var filtered = this.filtered(this.baggers);
       return filtered.sort(function(bagger1, bagger2){
-        if (bagger1.name < bagger2.name) return -1;
-        if (bagger1.name > bagger2.name) return 1;
-        return 0;
+        return bagger1.name.localeCompare(bagger2.name);
       })
     }
   },

--- a/js/vue-app.js
+++ b/js/vue-app.js
@@ -17,6 +17,16 @@ new Vue({
       body: null
     }
   },
+  computed: {
+    displayedBaggers: function(){
+      var filtered = this.filtered(this.baggers);
+      return filtered.sort(function(bagger1, bagger2){
+        if (bagger1.name < bagger2.name) return -1;
+        if (bagger1.name > bagger2.name) return 1;
+        return 0;
+      })
+    }
+  },
   methods: {
     // Filter baggers list
     filtered: function(baggers) {


### PR DESCRIPTION
The cities list is not visible on mobile. We have to scroll a lot in order to be able to select a city. So I propose to move this list on the left side of the page .

The list of baggers is now sorted by the name. 