### PR TITLE
Fix locations map

### DIFF
--- a/locations.html
+++ b/locations.html
@@ -98,7 +98,7 @@
 
     <script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor=true"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-    <script type="text/javascript" src="http://jquery-ui-map.googlecode.com/svn/trunk/ui/jquery.ui.map.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery-ui-map/3.0-rc1/jquery.ui.map.js"></script>
 
     <script type="text/javascript">
         $('#map_canvas').gmap({'callback': function() {


### PR DESCRIPTION
We are using an old URL which is giving back a 404 error.
I'm just fixing the URL to the `jquery.ui.map.js`.

But the fix might not be complete as google maps is now displaying a "For development purposes only" message.
We might have to fix that as well.